### PR TITLE
feature: Move Docker image to Alpine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,13 @@
-/vendor/
+# Ignore everything
+**
+
+# Allow files and directories
+!/composer.json
+!/composer.lock
+!/src
+!/tests
+!/docs
+
+# Ignore unnecessary files inside allowed directories
+# This should go after the allowed directories
+**/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-ARG PHP_IMAGE_VERSION=alpine3.14
+FROM alpine:3.14.2 as base
 
-FROM php:$PHP_IMAGE_VERSION as builder
+# HACK: Make iconv work on Alpine + PHP8
+# https://github.com/docker-library/php/issues/240#issuecomment-762763705
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ gnu-libiconv=1.15-r3 && \
+    apk add --no-cache php8 php8-phar php8-iconv php8-openssl php8-tokenizer php8-dom php8-mbstring php8-xmlwriter \
+    php8-xml
 
-RUN apk add composer
+FROM base as builder
+
+WORKDIR /workdir
+
+RUN ln -s /usr/bin/php8 /usr/bin/php && \
+    wget -O /usr/bin/composer https://getcomposer.org/download/2.1.9/composer.phar && \
+    chmod +x /usr/bin/composer
 
 COPY composer.json composer.json
 COPY composer.lock composer.lock
@@ -14,16 +25,16 @@ RUN composer test && composer check-formatting
 
 RUN composer install --no-dev
 
-FROM php:$PHP_IMAGE_VERSION
+FROM base
 WORKDIR /workdir
-RUN adduser -u 2004 -D docker
 COPY docs /docs
-RUN chown -R docker:docker . /docs
+RUN adduser -u 2004 -D docker && \
+    chown -R docker:docker . /docs
 USER docker
 
-COPY --from=builder vendor vendor
+COPY --from=builder /workdir/vendor vendor
 COPY src src
 
-ENTRYPOINT [ "php", "-d", "memory_limit=-1" ]
+ENTRYPOINT [ "php8", "-d", "memory_limit=-1" ]
 
 CMD [ "src/index.php" ]


### PR DESCRIPTION
It also shrinks the image a bit 🥳 
```
lorenzo@MacBook-Pro-di-Lorenzo ~/c/g/codacy-metrics-pdepend (use-alpine-docker-image)> docker image ls | grep codacy-metrics-pdepend
codacy-metrics-pdepend               latest                                                  4c4ccccea5c6   7 minutes ago    24.3MB
codacy/codacy-metrics-pdepend        latest                                                  8e1793dd888e   2 days ago       87.1MB
```