### PR TITLE
bump: docker base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@5.2.3
-  codacy_plugins_test: codacy/plugins-test@0.15.4
+  codacy: codacy/base@9.3.6
+  codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,12 @@
-FROM alpine:3.14.2 as base
+FROM alpine:3.17.0 as base
 
-# HACK: Make iconv work on Alpine + PHP8
-# https://github.com/docker-library/php/issues/240#issuecomment-762763705
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ gnu-libiconv=1.15-r3 && \
-    apk add --no-cache php8 php8-phar php8-iconv php8-openssl php8-tokenizer php8-dom php8-mbstring php8-xmlwriter \
-    php8-xml
+RUN apk add --no-cache php php-phar php-iconv php-openssl php-tokenizer php-dom php-mbstring php-xmlwriter php-xml
 
 FROM base as builder
 
 WORKDIR /workdir
 
-RUN ln -s /usr/bin/php8 /usr/bin/php && \
-    wget -O /usr/bin/composer https://getcomposer.org/download/2.1.9/composer.phar && \
-    chmod +x /usr/bin/composer
+RUN apk add --no-cache composer
 
 COPY composer.json composer.json
 COPY composer.lock composer.lock
@@ -35,6 +28,6 @@ USER docker
 COPY --from=builder /workdir/vendor vendor
 COPY src src
 
-ENTRYPOINT [ "php8", "-d", "memory_limit=-1" ]
+ENTRYPOINT [ "php", "-d", "memory_limit=-1" ]
 
 CMD [ "src/index.php" ]


### PR DESCRIPTION
Bumping orb version to remove vulnerabilities. Using alpine 3.17.0 which uses php8.1 is the default. There seems to be no issue with iconv, which allows to simplify the dockerfile. Also bumping orb versions to avoid issues in ci/cd pipelines.